### PR TITLE
pid1: propagate cancellation to all commands

### DIFF
--- a/pid1/main.go
+++ b/pid1/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"io"
 	"log"
 	"os"
@@ -10,12 +11,15 @@ import (
 )
 
 func main() {
-	commands := []*exec.Cmd{exec.Command("/sbin/chronyd", "-d")}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wg, ctx := errgroup.WithContext(ctx)
+
+	commands := []*exec.Cmd{exec.CommandContext(ctx, "/sbin/chronyd", "-d")}
 	for _, arg := range os.Args[1:] {
-		commands = append(commands, exec.Command(arg))
+		commands = append(commands, exec.CommandContext(ctx, arg))
 	}
 
-	var wg errgroup.Group
 	for _, cmd := range commands {
 		cmd := cmd
 


### PR DESCRIPTION
If one of the commands crashes or exits unexpectedly, it would leave the enclave in a hanging state as the final `wg.Wait` waits for the other commands to exit as well. This PR introduces a context that gets cancelled whenever _any_ command exits. It is passed to each command so that whenever that happens, all of them are killed as well.